### PR TITLE
enhancements to ease integration of sharness into other projects

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -724,6 +724,23 @@ rm -rf "$test_dir" || {
 	exit 1
 }
 
+
+#
+#  Load any extensions in $srcdir/sharness.d/*.sh
+#
+if test -d "${SHARNESS_TEST_SRCDIR}/sharness.d"; then
+	for file in "${SHARNESS_TEST_SRCDIR}"/sharness.d/*.sh; do
+		if test -n "$debug"; then
+			echo 2>&1 "Attempting to load ${file}"
+		fi
+		. "${file}"
+		if test $? != 0; then
+			echo 2>&1 "sharness: Error loading ${file}. Aborting."
+			exit 1
+		fi
+	done
+fi
+
 # Public: Empty trash directory, the test area, provided for each test. The HOME
 # variable is set to that directory too.
 export SHARNESS_TRASH_DIRECTORY

--- a/sharness.sh
+++ b/sharness.sh
@@ -691,6 +691,12 @@ test_done() {
 : ${SHARNESS_TEST_DIRECTORY:=$(pwd)}
 export SHARNESS_TEST_DIRECTORY
 
+#
+# Public: Source directory of test code and sharness library.
+#  This directory may be different from the directory in which tests are
+#  being run.
+: ${SHARNESS_TEST_SRCDIR:=$(cd `dirname $0` && pwd)}
+
 # Public: Build directory that will be added to PATH. By default, it is set to
 # the parent directory of SHARNESS_TEST_DIRECTORY.
 : ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_DIRECTORY/.."}

--- a/sharness.sh
+++ b/sharness.sh
@@ -630,7 +630,7 @@ test_done() {
 	if test -z "$HARNESS_ACTIVE"; then
 		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
 		mkdir -p "$test_results_dir"
-		test_results_path="$test_results_dir/${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}.$$.counts"
+		test_results_path="$test_results_dir/${SHARNESS_TEST_NAME}.$$.counts"
 
 		cat >>"$test_results_path" <<-EOF
 		total $test_count
@@ -701,8 +701,11 @@ export PATH SHARNESS_BUILD_DIRECTORY
 SHARNESS_TEST_FILE="$0"
 export SHARNESS_TEST_FILE
 
+SHARNESS_TEST_NAME=${SHARNESS_TEST_FILE##*/}
+SHARNESS_TEST_NAME=${SHARNESS_TEST_NAME%.${SHARNESS_TEST_EXTENSION}}
+
 # Prepare test area.
-test_dir="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
+test_dir="trash directory.$SHARNESS_TEST_NAME"
 test -n "$root" && test_dir="$root/$test_dir"
 case "$test_dir" in
 /*) SHARNESS_TRASH_DIRECTORY="$test_dir" ;;
@@ -727,10 +730,8 @@ mkdir -p "$test_dir" || exit 1
 # in subprocesses like git equals our $PWD (for pathname comparisons).
 cd -P "$test_dir" || exit 1
 
-this_test=${SHARNESS_TEST_FILE##*/}
-this_test=${this_test%.$SHARNESS_TEST_EXTENSION}
 for skp in $SKIP_TESTS; do
-	case "$this_test" in
+	case "$SHARNESS_TEST_NAME" in
 	$skp)
 		say_color info >&3 "skipping test $this_test altogether"
 		skip_all="skip all tests in $this_test"

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -315,6 +315,8 @@ test_expect_success 'tests can be run from an alternate directory' '
         (
           # unset SHARNESS variables before sub-test
 	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+	  # unset HARNESS_ACTIVE so we get a test-results dir
+	  unset HARNESS_ACTIVE &&
 	  chmod +x test.t &&
 	  mkdir test-rundir &&
 	  cd test-rundir &&

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -43,11 +43,11 @@ run_sub_test_lib_test () {
 		'
 
 		# Point to the test/sharness.sh, which isn't in ../ as usual
-		. "\$SHARNESS_TEST_DIRECTORY"/sharness.sh
+		. "\$SHARNESS_TEST_SRCDIR"/sharness.sh
 		EOF
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
-		export SHARNESS_TEST_DIRECTORY &&
+		export SHARNESS_TEST_SRCDIR &&
 		./".$name.t" --chain-lint >out 2>err
 	)
 }

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -297,6 +297,38 @@ test_expect_success 'We detect broken && chains' "
 	EOF
 "
 
+test_expect_success 'tests can be run from an alternate directory' '
+	# Act as if we have an installation of sharness in current dir:
+	ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+	export working_path="$(pwd)" &&
+	cat >test.t <<-EOF &&
+	test_description="test run of script from alternate dir"
+	. \$(dirname \$0)/sharness.sh
+	test_expect_success "success" "
+		true
+	"
+	test_expect_success "trash dir is subdir of working path" "
+		test \"\$(cd .. && pwd)\" = \"\$working_path/test-rundir\"
+	"
+	test_done
+	EOF
+        (
+          # unset SHARNESS variables before sub-test
+	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+	  chmod +x test.t &&
+	  mkdir test-rundir &&
+	  cd test-rundir &&
+	  ../test.t > output 2>err &&
+	  cat >expected <<-EOF &&
+	ok 1 - success
+	ok 2 - trash dir is subdir of working path
+	# passed all 2 test(s)
+	1..2
+	EOF
+	  test_cmp expected output &&
+	  test -d test-results
+	)
+'
 test_done
 
 # vi: set ft=sh :

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -329,6 +329,32 @@ test_expect_success 'tests can be run from an alternate directory' '
 	  test -d test-results
 	)
 '
+
+test_expect_success 'loading sharness extensions works' '
+	mkdir sharness.d &&
+	cat >sharness.d/test.sh <<-EOF &&
+	this_is_a_test() {
+		return 0
+	}
+	EOF
+	ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+	cat >test-extension.t <<-EOF &&
+	test_description="test sharness extensions"
+	. ./sharness.sh
+	test_expect_success "extension function is present" "
+		this_is_a_test
+	"
+	test_done
+	EOF
+	chmod +x ./test-extension.t &&
+	./test-extension.t >out 2>err &&
+	cat >expected <<-EOF &&
+	ok 1 - extension function is present
+	# passed all 1 test(s)
+	1..1
+	EOF
+	test_cmp expected out
+'
 test_done
 
 # vi: set ft=sh :


### PR DESCRIPTION
This pull request makes a few minor changes to `sharness.sh` making it slightly easier
to integrate sharness into projects without requiring much modification of the source.
It also enables sharness to work easily for projects where the directory of the sources
(i.e. the tests themselves) and the directory of the build products (and thus the directory in which  the tests are *run* during `make check`) are different.

The changes are pretty simple:

 - Fix some assumptions that the directory in which tests are being run is the same as the
   directory with the sources of the tests (and thus sharness.sh itself). With these fixes, it
   is now possible to replace `. ./sharness.sh` with `. $(dirname $0)/sharness.sh` and then
   run tests from an alternate directory. Test results and trash directories still go in the
   current working directory. This may be required for projects using VPATH builds.
 - Add a hook near the end of `sharness.sh` to load site or project specific extensions from
   `$SHARNESS_TEST_SRCDIR/sharness.d/*.sh`. This allows per-project customization,
   new test functions, etc to be added without modification of the sharness.sh itself.

There is also some simple tests for these new features added to `sharness.t`.

I understand if these changes are a bit too disruptive to accept. However, I decided to
propose them anyway, just in case they are useful for others.