### PR TITLE
Add a linter that detects broken && chains

### DIFF
--- a/README.git
+++ b/README.git
@@ -130,6 +130,14 @@ appropriately before running "make".
 	Using this option with a RAM-based filesystem (such as tmpfs)
 	can massively speed up the test suite.
 
+--chain-lint::
+--no-chain-lint::
+	If --chain-lint is enabled, the test harness will check each
+	test to make sure that it properly "&&-chains" all commands (so
+	that a failure in the middle does not go unnoticed by the final
+	exit code of the test). This check is performed in addition to
+	running the tests themselves.
+
 You can also set the GIT_TEST_INSTALLED environment variable to
 the bindir of an existing git installation to test that installation.
 You still need to have built this git sandbox, from which various

--- a/sharness.sh
+++ b/sharness.sh
@@ -68,6 +68,10 @@ while test "$#" -ne 0; do
 		# Ignore --quiet under a TAP::Harness. Saying how many tests
 		# passed without the ok/not ok details is always an error.
 		test -z "$HARNESS_ACTIVE" && quiet=t; shift ;;
+	--chain-lint)
+		chain_lint=t; shift ;;
+	--no-chain-lint)
+		chain_lint=; shift ;;
 	--no-color)
 		color=; shift ;;
 	--root=*)
@@ -298,6 +302,13 @@ test_run_() {
 	expecting_failure=$2
 	test_eval_ "$1"
 	eval_ret=$?
+
+	if test "$chain_lint" = "t"; then
+		test_eval_ "(exit 117) && $1"
+		if test "$?" != 117; then
+			error "bug in the test script: broken &&-chain: $1"
+		fi
+	fi
 
 	if test -z "$immediate" || test $eval_ret = 0 || test -n "$expecting_failure"; then
 		test_eval_ "$test_cleanup"

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -48,7 +48,7 @@ run_sub_test_lib_test () {
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
 		export SHARNESS_TEST_DIRECTORY &&
-		./".$name.t" >out 2>err
+		./".$name.t" --chain-lint >out 2>err
 	)
 }
 
@@ -283,6 +283,17 @@ test_expect_success 'cleanup functions tun at the end of the test' "
 	check_sub_test_lib_test cleanup-function <<-\\EOF
 	1..0
 	cleanup-function-called
+	EOF
+"
+
+test_expect_success 'We detect broken && chains' "
+	test_must_fail run_sub_test_lib_test \
+		broken-chain 'Broken && chain' <<-\\EOF
+	test_expect_success 'Cannot fail' '
+		true
+		true
+	'
+	test_done
 	EOF
 "
 


### PR DESCRIPTION
This is a straight-forward patch of a patch peff just posted to the git
mailing list:
(http://thread.gmane.org/gmane.comp.version-control.git/265874)

It adds a --chain-lint argument that will barf if you have a broken &&
chain in your test (and a test that tests whether it does).

You'll be pleased to know it detected no broken &&-chains in sharness :)