### PR TITLE
Use $SHELL instead of $SHELL_PATH in sharness.t

### DIFF
--- a/test/sharness.t
+++ b/test/sharness.t
@@ -34,7 +34,7 @@ run_sub_test_lib_test () {
 	(
 		cd "$name" &&
 		cat >".$name.t" <<-EOF &&
-		#!$SHELL_PATH
+		#!$SHELL
 
 		test_description='$descr (run in sub sharness)
 


### PR DESCRIPTION
In Git, test-lib.sh sources the GIT-BUILD-OPTIONS file
where SHELL_PATH is defined, and then exports SHELL_PATH,
so this environment variable is available to all the
test scripts.

In sharness there is no GIT-BUILD-OPTIONS so sharness.sh
doesn't have SHELL_PATH defined, and doesn't export it.
That's why it is not defined in sharness.t too, and it is
wrong to use it.

Now sharness.t still works because the following works:

$ cat >test.sh <<EOF
> #!
> echo "it works!"
> EOF
$ chmod +x test.sh
$ ./test.sh
it works!

but it is better to use $SHELL instead of $SHELL_PATH
anyway.