### PR TITLE
sharness.sh: export SHELL_PATH

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -28,6 +28,10 @@ export SHARNESS_TEST_EXTENSION
 # Keep the original TERM for say_color
 ORIGINAL_TERM=$TERM
 
+# Export SHELL_PATH
+: ${SHELL_PATH:=$SHELL}
+export SHELL_PATH
+
 # For repeatability, reset the environment to a known state.
 LANG=C
 LC_ALL=C


### PR DESCRIPTION
In Git, "test-lib.sh" sources the GIT-BUILD-OPTIONS file
where SHELL_PATH is defined, and then exports SHELL_PATH,
so this environment variable is available to all the
test scripts.

In sharness there is no GIT-BUILD-OPTIONS, so "sharness.sh"
doesn't have SHELL_PATH defined, and doesn't export it.

This is bad because SHELL_PATH is used in "sharness.t".

Now "sharness.t" still works because the following works:

```
$ cat >test.sh <<EOF
echo "it works!"
EOF
$ chmod +x test.sh
$ ./test.sh
it works!
```

But it's still better in "sharness.sh" to define SHELL_PATH
if it is not already defined and to export it.