### PR TITLE
README.md: fix go-ipfs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See how Sharness is used in real-world projects:
 * [cb2util](https://github.com/mlafeldt/cb2util/tree/master/test)
 * [dabba](https://github.com/eroullit/dabba/tree/master/dabba/test)
 * [git-integration](https://github.com/johnkeeping/git-integration/tree/master/t)
-* [go-ipfs](https://github.com/jbenet/go-ipfs/tree/master/test/sharness)
+* [go-ipfs](https://github.com/ipfs/go-ipfs/tree/master/test/sharness)
 * [go-multihash](https://github.com/jbenet/go-multihash/tree/master/test/sharness)
 * [rdd.py](https://github.com/mlafeldt/rdd.py/tree/master/test/integration)
 * [Sharness itself](/test)


### PR DESCRIPTION
go-ipfs is now hosted under https://github.com/ipfs/.