### PR TITLE
fix pathname of test-results/*.counts file

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -688,7 +688,7 @@ test_done() {
 	if test -z "$HARNESS_ACTIVE"; then
 		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
 		mkdir -p "$test_results_dir"
-		test_results_path="$test_results_dir/${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}.$$.counts"
+		test_results_path="$test_results_dir/$this_test.$$.counts"
 
 		cat >>"$test_results_path" <<-EOF
 		total $test_count


### PR DESCRIPTION
Define `$test_results_path` in terms of `$this_test`, not `${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}`.  The former is the basename of the latter, making it possible for `$0` to be an absolute path.