### PR TITLE
add SHARNESS_TEST_SRCDIR and a test for running from alternate directory

### DIFF
--- a/API.md
+++ b/API.md
@@ -325,8 +325,8 @@
 ### SHARNESS_TEST_SRCDIR
 
     Public: Source directory of test code and sharness library.
-     This directory may be different from the directory in which tests are
-     being run.
+    This directory may be different from the directory in which tests are
+    being run.
 
 ### SHARNESS_BUILD_DIRECTORY
 

--- a/API.md
+++ b/API.md
@@ -322,6 +322,12 @@
     Public: Root directory containing tests. Tests can override this variable,
     e.g. for testing Sharness itself.
 
+### SHARNESS_TEST_SRCDIR
+
+    Public: Source directory of test code and sharness library.
+     This directory may be different from the directory in which tests are
+     being run.
+
 ### SHARNESS_BUILD_DIRECTORY
 
     Public: Build directory that will be added to PATH. By default, it is set to

--- a/sharness.sh
+++ b/sharness.sh
@@ -749,6 +749,12 @@ test_done() {
 : ${SHARNESS_TEST_DIRECTORY:=$(pwd)}
 export SHARNESS_TEST_DIRECTORY
 
+# Public: Source directory of test code and sharness library.
+# This directory may be different from the directory in which tests are
+# being run.
+: ${SHARNESS_TEST_SRCDIR:=$(cd $(dirname $0) && pwd)}
+export SHARNESS_TEST_SRCDIR
+
 # Public: Build directory that will be added to PATH. By default, it is set to
 # the parent directory of SHARNESS_TEST_DIRECTORY.
 : ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_DIRECTORY/.."}

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -43,11 +43,11 @@ run_sub_test_lib_test () {
 		'
 
 		# Point to the test/sharness.sh, which isn't in ../ as usual
-		. "\$SHARNESS_TEST_DIRECTORY"/sharness.sh
+		. "\$SHARNESS_TEST_SRCDIR"/sharness.sh
 		EOF
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
-		export SHARNESS_TEST_DIRECTORY &&
+		export SHARNESS_TEST_SRCDIR &&
 		./".$name.t" --chain-lint >out 2>err
 	)
 }

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -297,6 +297,40 @@ test_expect_success 'We detect broken && chains' "
 	EOF
 "
 
+test_expect_success 'tests can be run from an alternate directory' '
+	# Act as if we have an installation of sharness in current dir:
+	ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+	export working_path="$(pwd)" &&
+	cat >test.t <<-EOF &&
+	test_description="test run of script from alternate dir"
+	. \$(dirname \$0)/sharness.sh
+	test_expect_success "success" "
+		true
+	"
+	test_expect_success "trash dir is subdir of working path" "
+		test \"\$(cd .. && pwd)\" = \"\$working_path/test-rundir\"
+	"
+	test_done
+	EOF
+        (
+          # unset SHARNESS variables before sub-test
+	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+	  # unset HARNESS_ACTIVE so we get a test-results dir
+	  unset HARNESS_ACTIVE &&
+	  chmod +x test.t &&
+	  mkdir test-rundir &&
+	  cd test-rundir &&
+	  ../test.t > output 2>err &&
+	  cat >expected <<-EOF &&
+	ok 1 - success
+	ok 2 - trash dir is subdir of working path
+	# passed all 2 test(s)
+	1..2
+	EOF
+	  test_cmp expected output &&
+	  test -d test-results
+	)
+'
 test_done
 
 # vi: set ft=sh :


### PR DESCRIPTION
This PR exports a `SHARNESS_TEST_SRCDIR` variable to differentiate sharness test *source* directory from the directory from which tests are running, i.e. as in `builddir` in a  VPATH build.

For now, use `SHARNESS_TEST_SRCDIR` in the sub-lib test as well as a new test that ensures
functionality of running tests from outside *srcdir*.