### PR TITLE
sort *.t test scripts before running them

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ PROVE ?= prove
 AGGREGATE_SCRIPT ?= aggregate-results.sh
 DEFAULT_TEST_TARGET ?= test
 
-T = $(wildcard *.t)
+T = $(sort $(wildcard *.t))
 
 all: $(DEFAULT_TEST_TARGET)
 


### PR DESCRIPTION
Starting with v3.82, GNU make's wildcard function no longer sorts the
results.  Use the sort function to ensure that the test scripts are
run in the intended order (e.g., so that quick smoke tests are run
before more thorough tests).