### PR TITLE
save original TERM before sanitization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ env:
   - TEST_OPTS=-v
   - DEFAULT_TEST_TARGET=prove
 
+before_install:
+  - sudo apt-get install libio-pty-perl # for test-terminal.perl
+
 install:
   - sudo make install prefix=/usr/local
 

--- a/API.md
+++ b/API.md
@@ -8,6 +8,10 @@
 
     Public: The file extension for tests.  By default, it is set to "t".
 
+### SHARNESS_ORIG_TERM
+
+    Public: The unsanitized TERM under which sharness is originally run
+
 ### test_set_prereq()
 
     Public: Define that a test prerequisite is available.

--- a/sharness.sh
+++ b/sharness.sh
@@ -25,6 +25,13 @@ export SHARNESS_VERSION
 : ${SHARNESS_TEST_EXTENSION:=t}
 export SHARNESS_TEST_EXTENSION
 
+#  Reset TERM to original terminal if found, otherwise save orignal TERM
+[ "x" = "x$SHARNESS_ORIG_TERM" ] &&
+		SHARNESS_ORIG_TERM="$TERM" ||
+		TERM="$SHARNESS_ORIG_TERM"
+# Public: The unsanitized TERM under which sharness is originally run
+export SHARNESS_ORIG_TERM
+
 # Export SHELL_PATH
 : ${SHELL_PATH:=$SHELL}
 export SHELL_PATH

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -38,6 +38,7 @@ test_terminal sh -c "test -t 1 && test -t 2" && test_set_prereq PERL_AND_TTY
 
 run_sub_test_lib_test () {
 	name="$1" descr="$2" # stdin is the body of the test code
+	prefix="$3"          # optionally run sub-test under command
 	mkdir "$name" &&
 	(
 		cd "$name" &&
@@ -56,7 +57,7 @@ run_sub_test_lib_test () {
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
 		export SHARNESS_TEST_SRCDIR &&
-		./".$name.t" --chain-lint >out 2>err
+		$prefix ./".$name.t" --chain-lint >out 2>err
 	)
 }
 

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -353,6 +353,17 @@ test_expect_success 'SHARNESS_ORIG_TERM propagated to sub-sharness' "
 	)
 "
 
+[ -z "$color" ] || test_set_prereq COLOR
+test_expect_success COLOR,PERL_AND_TTY 'sub-sharness still has color' "
+	run_sub_test_lib_test \
+	  test-color \
+	  'sub-sharness color check' \
+	  test_terminal <<-\\EOF
+	test_expect_success 'color is enabled' '[ -n \"\$color\" ]'
+	test_done
+	EOF
+"
+
 test_done
 
 # vi: set ft=sh :

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -331,6 +331,19 @@ test_expect_success 'tests can be run from an alternate directory' '
 	  test -d test-results
 	)
 '
+
+test_expect_success 'SHARNESS_ORIG_TERM propagated to sub-sharness' "
+	(
+	  export TERM=foo &&
+	  unset SHARNESS_ORIG_TERM &&
+	  run_sub_test_lib_test orig-term 'check original term' <<-\\EOF
+	test_expect_success 'SHARNESS_ORIG_TERM is foo' '
+		test \"x\$SHARNESS_ORIG_TERM\" = \"xfoo\" '
+	test_done
+	EOF
+	)
+"
+
 test_done
 
 # vi: set ft=sh :

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -32,6 +32,10 @@ test_terminal () {
 	perl "$SHARNESS_TEST_DIRECTORY"/test-terminal.perl "$@"
 }
 
+# If test_terminal works, then set a PERL_AND_TTY prereq for future tests:
+# (PERL and TTY prereqs may later be split if needed separately)
+test_terminal sh -c "test -t 1 && test -t 2" && test_set_prereq PERL_AND_TTY
+
 run_sub_test_lib_test () {
 	name="$1" descr="$2" # stdin is the body of the test code
 	mkdir "$name" &&

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -28,6 +28,10 @@ test_expect_failure 'pretend we have a known breakage' '
 	false
 '
 
+test_terminal () {
+	perl "$SHARNESS_TEST_DIRECTORY"/test-terminal.perl "$@"
+}
+
 run_sub_test_lib_test () {
 	name="$1" descr="$2" # stdin is the body of the test code
 	mkdir "$name" &&

--- a/test/test-terminal.perl
+++ b/test/test-terminal.perl
@@ -1,0 +1,80 @@
+#!/usr/bin/perl
+use 5.008;
+use strict;
+use warnings;
+use IO::Pty;
+use File::Copy;
+
+# Run @$argv in the background with stdio redirected to $out and $err.
+sub start_child {
+	my ($argv, $out, $err) = @_;
+	my $pid = fork;
+	if (not defined $pid) {
+		die "fork failed: $!"
+	} elsif ($pid == 0) {
+		open STDOUT, ">&", $out;
+		open STDERR, ">&", $err;
+		close $out;
+		exec(@$argv) or die "cannot exec '$argv->[0]': $!"
+	}
+	return $pid;
+}
+
+# Wait for $pid to finish.
+sub finish_child {
+	# Simplified from wait_or_whine() in run-command.c.
+	my ($pid) = @_;
+
+	my $waiting = waitpid($pid, 0);
+	if ($waiting < 0) {
+		die "waitpid failed: $!";
+	} elsif ($? & 127) {
+		my $code = $? & 127;
+		warn "died of signal $code";
+		return $code + 128;
+	} else {
+		return $? >> 8;
+	}
+}
+
+sub xsendfile {
+	my ($out, $in) = @_;
+
+	# Note: the real sendfile() cannot read from a terminal.
+
+	# It is unspecified by POSIX whether reads
+	# from a disconnected terminal will return
+	# EIO (as in AIX 4.x, IRIX, and Linux) or
+	# end-of-file.  Either is fine.
+	copy($in, $out, 4096) or $!{EIO} or die "cannot copy from child: $!";
+}
+
+sub copy_stdio {
+	my ($out, $err) = @_;
+	my $pid = fork;
+	defined $pid or die "fork failed: $!";
+	if (!$pid) {
+		close($out);
+		xsendfile(\*STDERR, $err);
+		exit 0;
+	}
+	close($err);
+	xsendfile(\*STDOUT, $out);
+	finish_child($pid) == 0
+		or exit 1;
+}
+
+if ($#ARGV < 1) {
+	die "usage: test-terminal program args";
+}
+my $master_out = new IO::Pty;
+my $master_err = new IO::Pty;
+$master_out->set_raw();
+$master_err->set_raw();
+$master_out->slave->set_raw();
+$master_err->slave->set_raw();
+my $pid = start_child(\@ARGV, $master_out->slave, $master_err->slave);
+close $master_out->slave;
+close $master_err->slave;
+copy_stdio($master_out, $master_err);
+exit(finish_child($pid));


### PR DESCRIPTION
I'm not sure if this one will be acceptable, but we have a use case where our sharness test will reinvoke itself under our framework.

Becuase `TERM` is now sanitized, we unnecessarily lose color output from the secondary sharness.

This change simply uses `SHARNESS_SAVED_TERM` to save the original `TERM` value, then resets `TERM` if `SHARNESS_SAVED_TERM` is found.