### PR TITLE
support $SHARNESS_TEST_SRCDIR/sharness.d directory for per-project extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Another way is to use [Sharnessify](https://github.com/chriscool/sharnessify).
 
 Alternatively, you can also add Sharness as a Git submodule to your project.
 
+In per-project installation, Sharness will optionally load extensions from
+`sharness.d/*.sh` if a `sharness.d` directory is found in the same directory
+as `sharness.sh`. This allows per-project extensions and enhancements to
+be added to the test library without requiring modification of `sharness.sh`.
+
 ### Per-user installation
 
     $ cd sharness

--- a/sharness.sh
+++ b/sharness.sh
@@ -786,6 +786,30 @@ rm -rf "$SHARNESS_TRASH_DIRECTORY" || {
 	exit 1
 }
 
+
+#
+#  Load any extensions in $srcdir/sharness.d/*.sh
+#
+if test -d "${SHARNESS_TEST_SRCDIR}/sharness.d"
+then
+	for file in "${SHARNESS_TEST_SRCDIR}"/sharness.d/*.sh
+	do
+		# Ensure glob was not an empty match:
+		test -e "${file}" || break
+
+		if test -n "$debug"
+		then
+			echo >&5 "sharness: loading extensions from ${file}"
+		fi
+		. "${file}"
+		if test $? != 0
+		then
+			echo >&5 "sharness: Error loading ${file}. Aborting."
+			exit 1
+		fi
+	done
+fi
+
 # Public: Empty trash directory, the test area, provided for each test. The HOME
 # variable is set to that directory too.
 export SHARNESS_TRASH_DIRECTORY


### PR DESCRIPTION
In our project that uses sharness, we want to extend sharness with project-specific test functions, modify `PATH` and other environments, and do other per-test-file setup. However, to make it easier
to stay in sync with upstream sharness, we'd like to avoid modifying sharness.sh directly.

This PR is an attempt to address this need by optionally loading "test library extensions" from
`$SHARNESS_TEST_SRCDIR/sharness.d/*.sh` if the directory exists. We support multiple
extension files in case some sharness users in the future create reusable libraries these can be
shared as is amongst interested parties by simply dropping them into the `sharness.d` directory.

I would not consider this something to submit to upstream git, as their `test-lib.sh` is only meant for
a single project. However, since the purpose of sharness is to be reused among many projects, I
thought this enhancement might be acceptable.

I also took a stab at updating `README.md`
