### PR TITLE
Use full path to create/enter trash directory

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -766,11 +766,11 @@ SHARNESS_TEST_FILE="$0"
 export SHARNESS_TEST_FILE
 
 # Prepare test area.
-test_dir="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
-test -n "$root" && test_dir="$root/$test_dir"
-case "$test_dir" in
-/*) SHARNESS_TRASH_DIRECTORY="$test_dir" ;;
- *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$test_dir" ;;
+SHARNESS_TRASH_DIRECTORY="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
+test -n "$root" && SHARNESS_TRASH_DIRECTORY="$root/$SHARNESS_TRASH_DIRECTORY"
+case "$SHARNESS_TRASH_DIRECTORY" in
+/*) ;; # absolute path is good
+ *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$SHARNESS_TRASH_DIRECTORY" ;;
 esac
 test "$debug" = "t" || remove_trash="$SHARNESS_TRASH_DIRECTORY"
 rm -rf "$SHARNESS_TRASH_DIRECTORY" || {

--- a/sharness.sh
+++ b/sharness.sh
@@ -773,7 +773,7 @@ case "$test_dir" in
  *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$test_dir" ;;
 esac
 test "$debug" = "t" || remove_trash="$SHARNESS_TRASH_DIRECTORY"
-rm -rf "$test_dir" || {
+rm -rf "$SHARNESS_TRASH_DIRECTORY" || {
 	EXIT_OK=t
 	echo >&5 "FATAL: Cannot prepare test area"
 	exit 1
@@ -786,10 +786,10 @@ export SHARNESS_TRASH_DIRECTORY
 HOME="$SHARNESS_TRASH_DIRECTORY"
 export HOME
 
-mkdir -p "$test_dir" || exit 1
+mkdir -p "$SHARNESS_TRASH_DIRECTORY" || exit 1
 # Use -P to resolve symlinks in our working directory so that the cwd
 # in subprocesses like git equals our $PWD (for pathname comparisons).
-cd -P "$test_dir" || exit 1
+cd -P "$SHARNESS_TRASH_DIRECTORY" || exit 1
 
 this_test=${SHARNESS_TEST_FILE##*/}
 this_test=${this_test%.$SHARNESS_TEST_EXTENSION}


### PR DESCRIPTION
If SHARNESS_TEST_DIRECTORY is not PWD, you cannot assume that you can create
and enter the trash directory without the full path.