### PR TITLE
Default SHARNESS_BUILD_DIRECTORY relative to SHARNESS_TEST_SRCDIR

### DIFF
--- a/API.md
+++ b/API.md
@@ -331,7 +331,7 @@
 ### SHARNESS_BUILD_DIRECTORY
 
     Public: Build directory that will be added to PATH. By default, it is set to
-    the parent directory of SHARNESS_TEST_DIRECTORY.
+    the parent directory of SHARNESS_TEST_SRCDIR.
 
 ### SHARNESS_TEST_FILE
 

--- a/sharness.sh
+++ b/sharness.sh
@@ -756,8 +756,8 @@ export SHARNESS_TEST_DIRECTORY
 export SHARNESS_TEST_SRCDIR
 
 # Public: Build directory that will be added to PATH. By default, it is set to
-# the parent directory of SHARNESS_TEST_DIRECTORY.
-: ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_DIRECTORY/.."}
+# the parent directory of SHARNESS_TEST_SRCDIR.
+: ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_SRCDIR/.."}
 PATH="$SHARNESS_BUILD_DIRECTORY:$PATH"
 export PATH SHARNESS_BUILD_DIRECTORY
 


### PR DESCRIPTION
This is in response to #28.

If you execute your test from another directory, you still want to use the same binary. So we should set the default SHARNESS_BUILD_DIRECTORY to the parent directory of SHARNESS_TEST_SRCDIR.