### PR TITLE
travis-ci: update to container build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
-language: erlang # no shell language support; use least-loaded worker(s)
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libio-pty-perl # for test-terminal.perl
 
 env:
   - TEST_OPTS=-v
   - DEFAULT_TEST_TARGET=prove
 
-before_install:
-  - sudo apt-get install libio-pty-perl # for test-terminal.perl
-
 install:
-  - sudo make install prefix=/usr/local
+  - make install prefix=$HOME/local
 
 script:
   - make test
-  - sudo make -C /usr/local/share/doc/sharness/examples
+  - make -C $HOME/local/share/doc/sharness/examples
 
 branches:
   only:


### PR DESCRIPTION
This is a proposal to update the sharness travis-ci build to the new container based builder.

See http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Travis-CI container builds start much faster (almost instantaneously) and travis is slowly deprecating the older VM based builds.

Since the container builds start so quickly, there is no reason to force the `language: erlang` setting, so that was removed.

The only caveat is that `sudo` is not allowed in container builds. However, placing the installed prefix under `$HOME` seems to work around this, and hopefully testing from that location is sufficient.