### PR TITLE
Support interactive tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The `*.t` test scripts have the following options (again, read
 * `--debug`, `-d`: helps debugging
 * `--immediate`, `-i`: stop execution after the first failing test
 * `--long-tests`, `-l`: run tests marked with prereq EXPENSIVE
+* `--interactive-tests`: run tests marked with prereq INTERACTIVE
 * `--help`, `-h`: show test description
 * `--verbose`, `-v`: show additional debug output
 * `--quiet`, `-q`: show less output

--- a/sharness.sh
+++ b/sharness.sh
@@ -66,6 +66,8 @@ while test "$#" -ne 0; do
 		immediate=t; shift ;;
 	-l|--l|--lo|--lon|--long|--long-|--long-t|--long-te|--long-tes|--long-test|--long-tests)
 		TEST_LONG=t; export TEST_LONG; shift ;;
+	--in|--int|--inte|--inter|--intera|--interac|--interact|--interacti|--interactiv|--interactive|--interactive-|--interactive-t|--interactive-te|--interactive-tes|--interactive-test|--interactive-tests):
+		TEST_INTERACTIVE=t; export TEST_INTERACTIVE; verbose=t; shift ;;
 	-h|--h|--he|--hel|--help)
 		help=t; shift ;;
 	-v|--v|--ve|--ver|--verb|--verbo|--verbos|--verbose)
@@ -316,7 +318,14 @@ test_pause() {
 test_eval_() {
 	# This is a separate function because some tests use
 	# "return" to end a test_expect_success block early.
-	eval </dev/null >&3 2>&4 "$*"
+	case ",$test_prereq," in
+	*,INTERACTIVE,*)
+		eval "$*"
+		;;
+	*)
+		eval </dev/null >&3 2>&4 "$*"
+		;;
+	esac
 }
 
 test_run_() {
@@ -834,5 +843,6 @@ for skp in $SKIP_TESTS; do
 done
 
 test -n "$TEST_LONG" && test_set_prereq EXPENSIVE
+test -n "$TEST_INTERACTIVE" && test_set_prereq INTERACTIVE
 
 # vi: set ts=4 sw=4 noet :

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -456,6 +456,12 @@ test_expect_success 'empty sharness.d directory does not cause failure' '
 	)
 '
 
+test_expect_success INTERACTIVE 'Interactive tests work' '
+    echo -n "Please type yes and hit enter " &&
+    read -r var &&
+    test "$var" = "yes"
+'
+
 test_done
 
 # vi: set ft=sh :


### PR DESCRIPTION
sharness redirects /dev/null to stdin for tests to make sure individual
tests accidently requiring input cannot hang the current test. However,
sometimes you just need to test an interactive program (for example,
when testing TOTP-based functionality). This patch lets you mark such
tests with the INTERACTIVE prereq and adds an --interactive-tests
argument to sharness.sh that will run those and will not redirect
/dev/null to the tests stdin when doing so.