### PR TITLE
sharness: properly ensure it ends with code 0

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -811,4 +811,7 @@ done
 
 test -n "$TEST_LONG" && test_set_prereq EXPENSIVE
 
+# Make sure this script ends with code 0
+:
+
 # vi: set ts=4 sw=4 noet :

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -21,6 +21,12 @@ test_description='Test Sharness itself'
 
 . ./sharness.sh
 
+ret="$?"
+
+test_expect_success 'sourcing sharness succeeds' '
+	test "$ret" = 0
+'
+
 test_expect_success 'success is reported like this' '
 	:
 '


### PR DESCRIPTION
It is better to have a `:` that ensures the script
ends with code 0, rather than rely on the previous
command.

This is an alternative to PR https://github.com/mlafeldt/sharness/pull/48